### PR TITLE
Hotfix/enable conversations dm and channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,6 +172,10 @@ async function main() {
     })
 
     async function handle_interaction_ask(interaction) {
+	    const user = interaction.user
+        
+        // Begin conversation
+	    let conversationInfo = Conversations.getConversation(user.id)
         const question = interaction.options.getString("question")
         try {
             await interaction.reply({ content: "let me think..." })
@@ -182,7 +186,7 @@ async function main() {
                 } else {
                     await interaction.editReply({ content })
                 }
-            })
+            }, { conversationInfo })
         } catch (e) {
             console.error(e)
         }

--- a/index.js
+++ b/index.js
@@ -96,10 +96,11 @@ async function main() {
 
         if (conversationInfo) {
             chatGTP.sendMessage(question,{
-                //conversationId:conversationInfo.conversationId,
+                conversationId: conversationInfo.conversationId,
+                parentMessageId: conversationInfo.parentMessageId
             }).then(response => {
                 conversationInfo.conversationId = response.conversationId
-                conversationInfo.parentMessageId = response.parentMessageId
+                conversationInfo.parentMessageId = response.messageId
                 clearTimeout(tmr)
                 cb(response.response)
             }).catch((e) => {


### PR DESCRIPTION
updated fix for conversation
This should enable conversations for DMs if DMs are enabled with `ENABLE_DIRECT_MESSAGES=true` and for server channel using the command `/ask`
The command `/ask` is still required for follow up questions on the conversation