### PR TITLE
Optimization for /ask command

### DIFF
--- a/discord/discord_commands.js
+++ b/discord/discord_commands.js
@@ -23,7 +23,7 @@ export const commands = [
                 choices: [
                 {
                     name: "Yes",
-                    "value": "true"
+                    value: "true"
                 },
                 {
                     name: "No",
@@ -82,11 +82,12 @@ export async function handle_interaction_ask(interaction) {
 
     // Begin conversation
     const question = interaction.options.getString("question")
+    const generateImage = interaction.options.getString("image") == "true" ? true : false;
     await interaction.deferReply()
 
     try {
         askQuestion(question, async (content) => {
-            generateInteractionReply(interaction, user, question, content)
+            generateInteractionReply(interaction, user, question, generateImage, content)
         })
     } catch (e) {
         console.error(e)

--- a/discord/discord_commands.js
+++ b/discord/discord_commands.js
@@ -15,7 +15,22 @@ export const commands = [
                 description: "Your question",
                 type: 3,
                 required: true
-            }
+            },
+            {
+                name: "image",
+                description: "Generate an image ?",
+                type: 3,
+                choices: [
+                {
+                    name: "Yes",
+                    "value": "true"
+                },
+                {
+                    name: "No",
+                    value: "false"
+                }
+            ]
+        }
         ]
     },
     {

--- a/discord/discord_helpers.js
+++ b/discord/discord_helpers.js
@@ -115,11 +115,12 @@ export async function splitAndSendResponse(resp, user) {
     }
 }
 
-export async function generateInteractionReply(interaction, user, question, content) {
+export async function generateInteractionReply(interaction, user, question, generateImage, content) {
     if (process.env.USE_EMBED.toLowerCase() == "true") {
         //embed
         const embed = createEmbedForAskCommand(user, question, content)
         await interaction.editReply({ embeds: [embed] }).catch(() => { })
+        if(generateImage) {
         let stableDiffusionPrompt = content.slice(0, Math.min(content.length, 200))
         stableDiffusion.generate(stableDiffusionPrompt, async (result) => {
             const results = result.results
@@ -132,6 +133,7 @@ export async function generateInteractionReply(interaction, user, question, cont
             embed.setImage("attachment://result0.jpg")
             await interaction.editReply({ embeds: [embed], files: [attachment] }).catch(() => { })
         })
+       }
     } else {
         //normal message
         if (content.length >= MAX_RESPONSE_CHUNK_LENGTH) {


### PR DESCRIPTION
Sometimes users may not want an image to be generated when `/ask` command is triggered. With this optimization, users can choose whether they want an image to be generated or not. This will save some unintended execution, therefore requiring less performance.